### PR TITLE
Filepaths with multiple periods in them will no longer prevent saving the graph

### DIFF
--- a/AgModel.py
+++ b/AgModel.py
@@ -479,7 +479,7 @@ if __name__ == "__main__":
         if pf == '':
             pass
         else:
-            plt.savefig(pf, format = pf.split('.')[1], edgecolor = "black")
+            plt.savefig(pf, format = pf.split('.')[-1], edgecolor = "black")
     else:
         pass
     eg.msgbox(msg='Close Simulation', title='Exit', ok_button='OK')


### PR DESCRIPTION
I have git repos on my filesystem in the pattern `~/projects/<site>/<org>/<repo>`, so this repo would be `~/projects/github.com/isaacullah/AgModel`. The previous method for extracting the format from the filepath would grab everything between `github` and the file extension rather than the file extension, and fail with `ValueError: Format 'com/isaacullah/agmodel/simulation_plot' is not supported (supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff, webp)` as a result . Now it assumes the final string segment contains the file extension which should work regardless of directory structure.